### PR TITLE
aggregate_pkg() to perform pre-aggregation in model_aggregate()

### DIFF
--- a/R/model_aggregate.R
+++ b/R/model_aggregate.R
@@ -9,7 +9,8 @@
 #' An attribute called `startCol` has been added to the output data frame to make this functionality work.
 #' 
 #'
-#' @param data A data frame containing data to be aggregated 
+#' @param data Input data containing data to be aggregated, typically a data frame, tibble, or data.table. 
+#'             If data is not a classic data frame, it will be coerced to one internally.  
 #' @param sum_vars Variables to be summed. This will be done via matrix multiplication. 
 #' @param fun_vars Variables to be aggregated by supplied functions.  
 #'      This will be done via \code{\link{aggregate_multiple_fun}} and \code{\link{dummy_aggregate}} and 
@@ -154,6 +155,14 @@ model_aggregate = function(
   pre_return = FALSE,
   verbose = TRUE,
   mm_args = NULL, ...) {
+  
+  data <- as.data.frame(data)
+  # Note: 
+  #   "if (!(pre_aggregate & aggregate_pkg == "data.table"))"
+  #       not used above 
+  # since then sum_data <- data.table::copy(data) needed below 
+  # but this is before the data.table availability check
+  
   
   if (!length(sum_vars)) {
     sum_vars <- NULL

--- a/man/model_aggregate.Rd
+++ b/man/model_aggregate.Rd
@@ -16,6 +16,9 @@ model_aggregate(
   preagg_var = NULL,
   dummy = TRUE,
   pre_aggregate = dummy,
+  aggregate_pkg = "base",
+  aggregate_na = TRUE,
+  aggregate_base_order = FALSE,
   list_return = FALSE,
   pre_return = FALSE,
   verbose = TRUE,
@@ -55,6 +58,17 @@ Note that all original \code{fun_vars} observations are retained in the aggregat
 However, \code{pre_aggregate} must be set to \code{FALSE} when the \code{dummy_aggregate} parameter \code{dummy} is set to \code{FALSE}
 since then \code{\link{unlist}} will not be run.
 An exception to this is if the \code{fun} functions are written to handle list data.}
+
+\item{aggregate_pkg}{Package used to pre-aggregate.
+Parameter \code{pkg} to \code{\link{aggregate_by_pkg}}.}
+
+\item{aggregate_na}{Whether to include NAs in the grouping variables while preAggregate.
+Parameter \code{include_na} to \code{\link{aggregate_by_pkg}}.}
+
+\item{aggregate_base_order}{Parameter \code{base_order} to \code{\link{aggregate_by_pkg}}, used when pre-aggregate.
+The default is set to \code{FALSE} to avoid unnecessary sorting operations.
+When \code{TRUE}, an attempt is made to return the same result with \code{data.table} as with base R.
+This cannot be guaranteed due to potential variations in sorting behavior across different systems.}
 
 \item{list_return}{Whether to return a list of separate components including the model matrix \code{x}.}
 

--- a/man/model_aggregate.Rd
+++ b/man/model_aggregate.Rd
@@ -27,7 +27,8 @@ model_aggregate(
 )
 }
 \arguments{
-\item{data}{A data frame containing data to be aggregated}
+\item{data}{Input data containing data to be aggregated, typically a data frame, tibble, or data.table.
+If data is not a classic data frame, it will be coerced to one internally.}
 
 \item{sum_vars}{Variables to be summed. This will be done via matrix multiplication.}
 


### PR DESCRIPTION
Make use of `aggregate_pkg()` to perform pre-aggregation in `model_aggregate()`. Additionally, ensure a call to `as.data.frame()` is included.

With these changes, `model_aggregate()` will behave similarly to `GaussSuppression::GaussSuppressionFromData()` and `SmallCountRounding::PLSrounding()`.

In particular, NAs in the grouping variables are now included during pre-aggregation. This can be especially useful when working with formula inputs (see the `NAomit` parameter to `Formula2ModelMatrix()`).
